### PR TITLE
Always use CDN and latest-stable in buildArch.sh

### DIFF
--- a/scripts/buildArch.sh
+++ b/scripts/buildArch.sh
@@ -55,7 +55,7 @@ case "$1" in
 esac
 
 #Install packages that we will need in UserLAnd
-echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> $ROOTFS_DIR/etc/apk/repositories
+echo "http://dl-cdn.alpinelinux.org/alpine/latest-stable/community" >> $ROOTFS_DIR/etc/apk/repositories
 LC_ALL=C LANGUAGE=C LANG=C chroot $ROOTFS_DIR apk update
 LC_ALL=C LANGUAGE=C LANG=C chroot $ROOTFS_DIR apk add bash sudo dropbear mesa-gl xvfb x11vnc xsetroot xterm twm expect shadow
 

--- a/scripts/buildArch.sh
+++ b/scripts/buildArch.sh
@@ -20,7 +20,7 @@ case "$1" in
 esac
 
 # APK Tool
-MIRROR=http://dl-5.alpinelinux.org/alpine
+MIRROR=http://dl-cdn.alpinelinux.org/alpine
 VERSION=latest-stable
 APK_TOOL=apk-tools-static-2.10.3-r1.apk
 


### PR DESCRIPTION
Two minor changes to buildArch.sh:

- to always pull packages via the CDN and
- to use latest-stable consistently 